### PR TITLE
feat: add LangGraph orchestration backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests
+        run: uv run pytest tests/ --ignore=tests/test_temporal_runner.py -v
+        env:
+          MOCK_PII: "1"

--- a/LANGGRAPH.md
+++ b/LANGGRAPH.md
@@ -1,0 +1,160 @@
+# LangGraph Orchestration Backend
+
+This document describes the LangGraph implementation of the auditguard-mcp pipeline orchestration layer. The async and Temporal backends remain unchanged; this is a third selectable backend.
+
+---
+
+## Why LangGraph
+
+| Concern | LangGraph | async | Temporal |
+|---|---|---|---|
+| Branching logic | Explicit graph edges | Imperative if-else | Workflow signals |
+| Observability | Node-level event stream | No built-in | Event history |
+| Durability | None (same as async) | None | Cross-process, durable |
+| Operational complexity | Zero (in-process) | Zero | Temporal cluster required |
+| Future checkpointing | Drop-in `SqliteSaver` / `PostgresSaver` | Major refactor | Already durable |
+
+Choose LangGraph when you want transparent routing and future extensibility (streaming, tracing via LangSmith, or durable replay via a checkpointer) without the operational cost of a Temporal cluster.
+
+---
+
+## Configuration
+
+```bash
+export AUDITGUARD_BACKEND=langgraph   # or: async (default), temporal
+```
+
+Or in code:
+```python
+from auditguard_mcp.config import set_config, get_config
+set_config(get_config().model_copy(update={"backend": "langgraph"}))
+```
+
+---
+
+## Graph Topology
+
+```mermaid
+flowchart TD
+    START([__start__]) --> rbac
+
+    rbac -->|route=rbac_denied| audit_log
+    rbac -->|route=continue| scan_inbound
+
+    scan_inbound --> policy_inbound
+
+    policy_inbound -->|route=short_circuit| audit_log
+    policy_inbound -->|route=human_review| audit_log
+    policy_inbound -->|route=continue| execute
+
+    execute --> scan_outbound
+    scan_outbound --> policy_outbound
+    policy_outbound --> audit_log
+
+    audit_log --> END([__end__])
+```
+
+All short-circuit paths converge on `audit_log`, guaranteeing a structured audit record regardless of where the pipeline exits.
+
+---
+
+## State Schema
+
+`PipelineState` is a `TypedDict` threaded through every node. Nodes return partial dicts; LangGraph merges updates by key overwrite.
+
+| Field | Type | Set by |
+|---|---|---|
+| `request` | `AuditRequest` | caller |
+| `context` | `AuditContext` | caller |
+| `decisions` | `list[PipelineDecision]` | `policy_inbound`, `policy_outbound` |
+| `inbound_pii` | `PIIScanResult \| None` | `scan_inbound` |
+| `outbound_pii` | `PIIScanResult \| None` | `scan_outbound` |
+| `inbound_detections` | `list[PIIDetection] \| None` | `scan_inbound` |
+| `outbound_detections` | `list[PIIDetection] \| None` | `scan_outbound` |
+| `output` | `str \| None` | `execute`, `policy_outbound` (on BLOCK) |
+| `status` | `RequestStatus` | `rbac`, `policy_inbound`, `policy_outbound` |
+| `error` | `str \| None` | `rbac`, `policy_inbound` |
+| `start_time` | `float` | caller (monotonic) |
+| `route` | `str` | `rbac`, `policy_inbound` |
+| `log_entry` | `PipelineLogEntry \| None` | `audit_log` |
+
+**Mutation contract:** only the node listed in _Set by_ writes each field. `decisions` is overwritten with the full updated list (not appended in-place) to keep state serializable.
+
+---
+
+## Node-by-Node Mapping
+
+| Node | Stage | `stages.py` function | Notes |
+|---|---|---|---|
+| `rbac` | 1 | `check_rbac` | Catches `RBACDenied`; sets `route=rbac_denied` |
+| `scan_inbound` | 2 | `scan_inbound_pii` | CPU-bound; run via `asyncio.to_thread` |
+| `policy_inbound` | 3 | `apply_inbound_policy` | Sets `route` for conditional edge |
+| `execute` | 4 | `execute_bounded` | Async; enforces timeout via `asyncio.wait_for` |
+| `scan_outbound` | 5 | `scan_outbound_pii` | CPU-bound; run via `asyncio.to_thread` |
+| `policy_outbound` | 6 | `apply_outbound_policy` | Overwrites `output` on BLOCK |
+| `audit_log` | 7 | `write_audit_log` | Terminal node; always runs; writes JSONL |
+
+All nodes are `async def`. Synchronous stage functions are dispatched with `asyncio.to_thread`.
+
+---
+
+## Branching Rules
+
+| After node | `route` value | Next node | `status` set |
+|---|---|---|---|
+| `rbac` | `continue` | `scan_inbound` | — |
+| `rbac` | `rbac_denied` | `audit_log` | `RBAC_DENIED` |
+| `policy_inbound` | `continue` | `execute` | — |
+| `policy_inbound` | `short_circuit` | `audit_log` | `BLOCKED` |
+| `policy_inbound` | `human_review` | `audit_log` | `REVIEW_QUEUED` |
+| `policy_outbound` | _(no routing)_ | `audit_log` | `BLOCKED` if action is BLOCK/DENY |
+
+`policy_outbound` has no conditional edge — it always proceeds to `audit_log` and updates `status` and `output` inline when needed.
+
+---
+
+## Error Handling
+
+The public entrypoint `run_audit_pipeline_langgraph` runs the graph via `astream(stream_mode="values")` rather than `ainvoke`, updating `last_state` after each node snapshot. If any node raises an unexpected exception:
+
+1. `last_state` holds the accumulated decisions and detections up to the failing node.
+2. The except block calls `write_audit_log` directly using `last_state`, preserving partial audit trail.
+3. `status` is set to `ERROR`; `final_action` reflects whatever decisions were completed.
+
+This matches the async backend's error-path behaviour and avoids the data-loss risk of using the empty `initial_state` in the handler.
+
+---
+
+## Tradeoffs vs Other Backends
+
+**vs async backend**
+- Extra dependencies: `langgraph`, `langchain-core` (already in core deps for agent examples).
+- Small overhead: graph compilation (~0ms, done once at import) and per-call state dict allocation (~1-2ms).
+- Same durability guarantee: in-process only; no persistence across crashes.
+- Benefit: routing is inspectable via `_PIPELINE_GRAPH.get_graph()` and streamable for external observers.
+
+**vs Temporal backend**
+- No cross-process durability: if the worker dies mid-pipeline, the request is lost (same as async).
+- No durable human-in-the-loop: `HUMAN_REVIEW` short-circuits immediately instead of waiting on a signal.
+- No per-stage retry policies.
+- Future path: wire a [LangGraph checkpointer](https://langchain-ai.github.io/langgraph/concepts/persistence/) (`SqliteSaver`, `PostgresSaver`) to gain cross-process persistence without restructuring the graph.
+
+---
+
+## Running the Demo
+
+```bash
+# Fast demo (mock PII detector, no model download)
+uv run python examples/run_langgraph_backend.py
+```
+
+---
+
+## Running Tests
+
+```bash
+uv run pytest tests/test_langgraph_runner.py -v
+
+# Regression check -- stages.py is shared; confirm other backends unaffected
+uv run pytest tests/test_async_runner.py tests/test_pipeline_stages.py -v
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The fix is not a bolt-on. The fix is a pipeline that gates every tool call throu
 
 ## Architecture: ports and adapters
 
-The pipeline uses a ports-and-adapters (hexagonal) pattern. Stage logic lives in `pipeline/stages.py` as pure functions. No IO, no framework dependencies, easy to test. Each orchestration backend (`async_runner.py`, `temporal_runner.py`) is a thin adapter that calls those functions in sequence. Adding a third backend (AWS Step Functions, Celery) is roughly 100 lines of adapter code, not a rewrite.
+The pipeline uses a ports-and-adapters (hexagonal) pattern. Stage logic lives in `pipeline/stages.py` as pure functions. No IO, no framework dependencies, easy to test. Each orchestration backend (`async_runner.py`, `langgraph_runner.py`, `temporal_runner.py`) is a thin adapter that calls those functions in sequence. Adding another backend (AWS Step Functions, Celery) is roughly 100 lines of adapter code, not a rewrite.
 
 The design is **fail-closed**. Unparseable SQL always triggers `RBACDenied`. Missing policy categories default to `ALLOW` explicitly. Audit records never contain raw PII.
 
@@ -65,17 +65,20 @@ Same detection pipeline. Same engine. Same audit logger. Only the config differs
 
 A regulator can verify that the pipeline ran, inspect every decision, and confirm the policy version in effect at the time. They cannot reconstruct the customer's SSN from the audit log. That is the point.
 
-## Infrastructure: Temporal, Docker, async
+## Infrastructure: Temporal, LangGraph, async
 
-Two orchestration backends for the same 7-stage pipeline:
+Three orchestration backends for the same 7-stage pipeline:
 
-| | Async (default) | Temporal |
-|---|---|---|
-| Latency overhead | None | ~50-100ms per stage |
-| Durability | Lost on crash | Resumes from last completed stage |
-| Human-in-the-loop | No | 24-hour signal timeout |
-| Retry per stage | No | Independent policies (RBAC: 3 attempts, Audit: 20) |
-| Operational cost | Zero | Temporal cluster + worker process |
+| | Async (default) | LangGraph | Temporal |
+|---|---|---|---|
+| Latency overhead | None | ~1-5ms | ~50-100ms per stage |
+| Durability | Lost on crash | Lost on crash | Resumes from last completed stage |
+| Human-in-the-loop | No | No (short-circuits) | 24-hour signal timeout |
+| Retry per stage | No | No | Independent policies (RBAC: 3 attempts, Audit: 20) |
+| Operational cost | Zero | Zero | Temporal cluster + worker process |
+| Routing model | Imperative if-else | Explicit graph edges | Deterministic workflow |
+
+The LangGraph backend (`langgraph_runner.py`) models the pipeline as a `StateGraph` — each stage is a node, branching logic lives in conditional edges, and partial state is preserved via streaming snapshots so error-path audit records are as complete as success-path ones. See [`LANGGRAPH.md`](LANGGRAPH.md) for the full graph topology, state schema, and design rationale.
 
 The Temporal workflow (`temporal_runner.py`) handles `ActivityError` unwrapping for RBAC denial, heartbeating for long model inference, and human review signals. Temporal tests use an in-memory server. No Docker needed for CI.
 
@@ -115,13 +118,13 @@ RBAC denies without touching the PII model. The PII model runs before the tool, 
 
 ## Quality: tests, eval, benchmarks
 
-- **108 tests** across unit, integration, and pipeline stages (`tests/`)
+- **116 tests** across unit, integration, and pipeline stages (`tests/`)
 - **Golden-set eval harness** with 15 test cases measuring RBAC accuracy, PII detection accuracy, and audit completeness (`eval/`)
 - **Latency benchmarks** reporting p50/p90/p95/p99 for the 1.5B model on CPU (`benchmarks/`)
 
 ## Full-stack demo
 
-- **Interactive web demo** (`web/index.html`): single-page app with real-time pipeline visualization, MCP Streamable HTTP client, and animated 7-step status indicators. Shows backend type (async/temporal) and links to Temporal UI for workflow inspection.
+- **Interactive web demo** (`web/index.html`): single-page app with real-time pipeline visualization, MCP Streamable HTTP client, and animated 7-step status indicators. Shows backend type (async/langgraph/temporal) with a colour-coded chip; links to Temporal UI for workflow inspection.
 - **Synthetic financial dataset** (`scripts/seed_data.py`): realistic data with deliberate PII edge cases (aliases, compound identifiers, one-hop references).
 
 ## What this is not
@@ -147,6 +150,13 @@ MOCK_PII=1 make demo
 # -> http://localhost:7860
 ```
 
+For LangGraph backend (no extra infra):
+
+```bash
+AUDITGUARD_BACKEND=langgraph MOCK_PII=1 uv run python web_app.py
+# -> http://localhost:7860  (chip shows "LangGraph" in blue)
+```
+
 For Temporal backend:
 
 ```bash
@@ -164,7 +174,7 @@ AUDITGUARD_BACKEND=temporal uv run uvicorn web_app:app --port 7860             #
 | MCP Server | FastMCP (stdio + Streamable HTTP) |
 | PII Detection | OpenAI Privacy Filter 1.5B (local CPU) |
 | SQL Parsing | sqlglot |
-| Orchestration | asyncio / Temporal |
+| Orchestration | asyncio / LangGraph / Temporal |
 | Web Framework | FastAPI + Uvicorn |
 | Database | SQLite (synthetic) |
 | Container | Docker (multi-layer, CPU-only ML deps) |

--- a/auditguard_mcp/config.py
+++ b/auditguard_mcp/config.py
@@ -23,10 +23,10 @@ class AuditConfig(BaseModel):
         temporal_task_queue: Temporal task queue name (only used if backend=='temporal').
     """
 
-    backend: Literal["async", "temporal"] = Field(
+    backend: Literal["async", "temporal", "langgraph"] = Field(
         default="async",
         description="Orchestration backend. 'async' for low-latency single-process. "
-        "'temporal' for durable execution.",
+        "'temporal' for durable execution. 'langgraph' for graph-native orchestration.",
     )
     policy_mode: Literal["permissive", "strict"] = "permissive"
     pii_threshold: float = 0.7

--- a/auditguard_mcp/pipeline/langgraph_runner.py
+++ b/auditguard_mcp/pipeline/langgraph_runner.py
@@ -1,0 +1,333 @@
+"""LangGraph backend -- graph-native orchestration of the 7-stage audit pipeline.
+
+Why LangGraph:
+- Explicit graph topology makes branching logic inspectable and testable
+- Conditional edges encode short-circuit rules without nested if-else chains
+- Graph compilation validates routing before runtime
+- Future: add a checkpointer (SqliteSaver / PostgresSaver) for cross-process
+  durability, streaming node events, or LangSmith tracing -- no restructuring
+  needed
+
+Tradeoffs vs async backend:
+- Small overhead from graph compilation and state serialization (~1-5ms)
+- Extra dependencies (langgraph, langchain-core)
+- Same durability gap as async: no cross-process persistence without a
+  checkpointer
+
+Tradeoffs vs Temporal:
+- No built-in durable retry across worker crashes (Temporal's core value)
+- No human-in-the-loop signal mechanism (implemented as immediate short-circuit)
+- Much simpler operationally -- no Temporal cluster required
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any, TypedDict
+
+from langgraph.graph import StateGraph, END
+
+from auditguard_mcp.models import PIIDetection, RBACDenied, RequestStatus
+
+from .stages import (
+    apply_inbound_policy,
+    apply_outbound_policy,
+    check_rbac,
+    execute_bounded,
+    scan_inbound_pii,
+    scan_outbound_pii,
+    write_audit_log,
+)
+from .types import (
+    AuditContext,
+    AuditRequest,
+    PIIScanResult,
+    PipelineAction,
+    PipelineDecision,
+    PipelineLogEntry,
+)
+
+
+# ============================================================================
+# Pipeline state -- the shared bag passed between nodes
+# ============================================================================
+
+class PipelineState(TypedDict, total=False):
+    """Mutable state threaded through the graph.
+
+    Each node receives the full state and returns a partial dict of updates.
+    LangGraph merges returned updates into the state by key overwrite.
+    """
+    request: AuditRequest
+    context: AuditContext
+
+    # Accumulated scan results
+    inbound_pii: PIIScanResult | None
+    outbound_pii: PIIScanResult | None
+
+    # Deserialized detection objects for audit log
+    inbound_detections: list[PIIDetection] | None
+    outbound_detections: list[PIIDetection] | None
+
+    # Growing list of stage decisions (inbound, then outbound)
+    decisions: list[PipelineDecision]
+
+    # Tool output after execution
+    output: str | None
+
+    # Pipeline-level status and error
+    status: RequestStatus
+    error: str | None
+
+    # Monotonic start time for duration calculation
+    start_time: float
+
+    # Routing signal read by conditional edges
+    # Values: "continue" | "short_circuit" | "rbac_denied" | "human_review"
+    route: str
+
+    # Final result populated by the audit_log node
+    log_entry: PipelineLogEntry | None
+
+
+# ============================================================================
+# Nodes -- one per pipeline stage
+# ============================================================================
+
+async def node_rbac(state: PipelineState) -> dict[str, Any]:
+    """Stage 1: RBAC check. Short-circuits to audit_log on denial."""
+    request = state["request"]
+    context = state["context"]
+    try:
+        await asyncio.to_thread(check_rbac, request, context)
+        return {"route": "continue"}
+    except RBACDenied as e:
+        error_msg = str(e)
+        denial = PipelineDecision(
+            action=PipelineAction.DENY,
+            reason=error_msg,
+            triggered_rules=["rbac"],
+            sanitized_text=json.dumps({"error": error_msg}),
+            categories=[],
+        )
+        return {
+            "decisions": [denial],
+            "status": RequestStatus.RBAC_DENIED,
+            "error": error_msg,
+            "route": "rbac_denied",
+        }
+
+
+async def node_scan_inbound(state: PipelineState) -> dict[str, Any]:
+    """Stage 2: Inbound PII scan."""
+    pii = await asyncio.to_thread(scan_inbound_pii, state["request"], state["context"])
+    detections = [PIIDetection.model_validate(d) for d in pii.detections]
+    return {
+        "inbound_pii": pii,
+        "inbound_detections": detections,
+    }
+
+
+async def node_policy_inbound(state: PipelineState) -> dict[str, Any]:
+    """Stage 3: Inbound policy. Sets route for conditional edge."""
+    decision = await asyncio.to_thread(
+        apply_inbound_policy,
+        state["request"],
+        state["inbound_pii"],
+        state["context"],
+    )
+    decisions = list(state.get("decisions") or [])
+    decisions.append(decision)
+
+    if decision.action in (PipelineAction.DENY, PipelineAction.BLOCK):
+        return {
+            "decisions": decisions,
+            "status": RequestStatus.BLOCKED,
+            "error": "Inbound policy denied or blocked the request",
+            "route": "short_circuit",
+        }
+    if decision.action == PipelineAction.HUMAN_REVIEW:
+        # Async backend parity: queue review and return immediately
+        return {
+            "decisions": decisions,
+            "status": RequestStatus.REVIEW_QUEUED,
+            "error": "Human review required (langgraph backend cannot wait)",
+            "route": "human_review",
+        }
+    return {"decisions": decisions, "route": "continue"}
+
+
+async def node_execute(state: PipelineState) -> dict[str, Any]:
+    """Stage 4: Bounded tool execution."""
+    inbound_decision = state["decisions"][-1]
+    output = await execute_bounded(state["request"], inbound_decision, state["context"])
+    return {"output": output}
+
+
+async def node_scan_outbound(state: PipelineState) -> dict[str, Any]:
+    """Stage 5: Outbound PII scan."""
+    output = state.get("output") or ""
+    pii = await asyncio.to_thread(scan_outbound_pii, output, state["context"])
+    detections = [PIIDetection.model_validate(d) for d in pii.detections]
+    return {
+        "outbound_pii": pii,
+        "outbound_detections": detections,
+    }
+
+
+async def node_policy_outbound(state: PipelineState) -> dict[str, Any]:
+    """Stage 6: Outbound policy."""
+    output = state.get("output") or ""
+    decision = await asyncio.to_thread(
+        apply_outbound_policy,
+        output,
+        state["outbound_pii"],
+        state["context"],
+    )
+    decisions = list(state.get("decisions") or [])
+    decisions.append(decision)
+
+    updates: dict[str, Any] = {"decisions": decisions}
+    if decision.action in (PipelineAction.DENY, PipelineAction.BLOCK):
+        updates["status"] = RequestStatus.BLOCKED
+        updates["output"] = decision.sanitized_text
+    return updates
+
+
+async def node_audit_log(state: PipelineState) -> dict[str, Any]:
+    """Stage 7: Write structured audit log. Always runs -- terminal node."""
+    request = state["request"]
+    context = state["context"]
+    decisions = state.get("decisions") or []
+    start_time = state["start_time"]
+    duration_ms = int((time.monotonic() - start_time) * 1000)
+
+    log_entry = write_audit_log(
+        request=request,
+        output=state.get("output"),
+        decisions=decisions,
+        context=context,
+        duration_ms=duration_ms,
+        backend="langgraph",
+        inbound_detections=state.get("inbound_detections"),
+        outbound_detections=state.get("outbound_detections"),
+        status=state.get("status", RequestStatus.SUCCESS),
+        error=state.get("error"),
+    )
+    return {"log_entry": log_entry}
+
+
+# ============================================================================
+# Routing functions -- read the route key from state
+# ============================================================================
+
+def route_after_rbac(state: PipelineState) -> str:
+    return "audit_log" if state["route"] == "rbac_denied" else "scan_inbound"
+
+
+def route_after_policy_inbound(state: PipelineState) -> str:
+    route = state["route"]
+    if route in ("short_circuit", "human_review"):
+        return "audit_log"
+    return "execute"
+
+
+# ============================================================================
+# Graph construction
+# ============================================================================
+
+def _build_graph() -> Any:
+    graph = StateGraph(PipelineState)
+
+    graph.add_node("rbac", node_rbac)
+    graph.add_node("scan_inbound", node_scan_inbound)
+    graph.add_node("policy_inbound", node_policy_inbound)
+    graph.add_node("execute", node_execute)
+    graph.add_node("scan_outbound", node_scan_outbound)
+    graph.add_node("policy_outbound", node_policy_outbound)
+    graph.add_node("audit_log", node_audit_log)
+
+    graph.set_entry_point("rbac")
+
+    graph.add_conditional_edges(
+        "rbac",
+        route_after_rbac,
+        {"scan_inbound": "scan_inbound", "audit_log": "audit_log"},
+    )
+    graph.add_edge("scan_inbound", "policy_inbound")
+    graph.add_conditional_edges(
+        "policy_inbound",
+        route_after_policy_inbound,
+        {"execute": "execute", "audit_log": "audit_log"},
+    )
+    graph.add_edge("execute", "scan_outbound")
+    graph.add_edge("scan_outbound", "policy_outbound")
+    graph.add_edge("policy_outbound", "audit_log")
+    graph.add_edge("audit_log", END)
+
+    return graph.compile()
+
+
+# Module-level compiled graph (built once, reused across calls)
+_PIPELINE_GRAPH = _build_graph()
+
+
+# ============================================================================
+# Public entrypoint
+# ============================================================================
+
+async def run_audit_pipeline_langgraph(
+    request: AuditRequest,
+    context: AuditContext,
+) -> PipelineLogEntry:
+    """Runs the 7-stage audit pipeline as a LangGraph StateGraph.
+
+    Semantically equivalent to run_audit_pipeline_async: same stages, same
+    branching rules, same audit log format. Differences are in how control
+    flow is expressed (explicit graph edges vs. imperative if-else).
+    """
+    initial_state: PipelineState = {
+        "request": request,
+        "context": context,
+        "decisions": [],
+        "inbound_pii": None,
+        "outbound_pii": None,
+        "inbound_detections": None,
+        "outbound_detections": None,
+        "output": None,
+        "status": RequestStatus.SUCCESS,
+        "error": None,
+        "start_time": time.monotonic(),
+        "route": "continue",
+        "log_entry": None,
+    }
+
+    # Stream values so we always hold the latest merged state.
+    # If a node raises mid-pipeline, last_state preserves every decision and
+    # detection accumulated before the crash -- not the empty initial_state.
+    last_state: PipelineState = initial_state
+    try:
+        async for snapshot in _PIPELINE_GRAPH.astream(initial_state, stream_mode="values"):
+            last_state = snapshot
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        duration_ms = int((time.monotonic() - initial_state["start_time"]) * 1000)
+        return write_audit_log(
+            request=request,
+            output=last_state.get("output"),
+            decisions=last_state.get("decisions") or [],
+            context=context,
+            duration_ms=duration_ms,
+            backend="langgraph",
+            inbound_detections=last_state.get("inbound_detections"),
+            outbound_detections=last_state.get("outbound_detections"),
+            status=RequestStatus.ERROR,
+            error=error_msg,
+        )
+
+    log_entry = last_state.get("log_entry")
+    if log_entry is None:
+        raise RuntimeError("LangGraph pipeline completed without a log entry")
+
+    return log_entry

--- a/auditguard_mcp/pipeline/types.py
+++ b/auditguard_mcp/pipeline/types.py
@@ -114,7 +114,7 @@ class PipelineLogEntry(BaseModel):
     decisions: list[PipelineDecision]
     final_action: PipelineAction
     duration_ms: int
-    backend: Literal["async", "temporal"]
+    backend: Literal["async", "temporal", "langgraph"]
     status: str = "success"
     error: str | None = None
 

--- a/auditguard_mcp/server.py
+++ b/auditguard_mcp/server.py
@@ -286,12 +286,28 @@ def _emit_audit(
 # v2 Pipeline dispatch
 # ---------------------------------------------------------------------------
 
+_NON_SUCCESS_STATUSES = {"rbac_denied", "blocked", "error"}
+
+
+def _extract_output(result: "PipelineLogEntry", backend: str) -> tuple[str, dict]:
+    """Convert a PipelineLogEntry to the (tool_output, backend_meta) tuple.
+
+    Non-success statuses always return error JSON -- never sanitized_text.
+    sanitized_text on a BLOCK decision holds the *original* blocked content
+    (set by stages.apply_inbound_policy / apply_outbound_policy on PolicyViolation),
+    so returning it would leak the blocked SSN / PII back to the MCP client.
+    """
+    meta = {"backend": backend}
+    if result.status in _NON_SUCCESS_STATUSES or result.error:
+        return json.dumps({"error": result.error or result.status}), meta
+    return result.decisions[-1].sanitized_text if result.decisions else "", meta
+
 
 async def _run_pipeline_v2(
     request: AuditRequest,
     context: AuditContext,
 ) -> tuple[str, dict | None]:
-    """Dispatch to the configured backend (async or Temporal).
+    """Dispatch to the configured backend (async, temporal, or langgraph).
 
     Returns (tool_output, backend_meta). backend_meta is None for async,
     or a dict with workflow_id/run_id for Temporal.
@@ -306,19 +322,14 @@ async def _run_pipeline_v2(
             )
         return await _run_temporal(request, context)
 
+    if config.backend == "langgraph":
+        from auditguard_mcp.pipeline.langgraph_runner import run_audit_pipeline_langgraph
+        result = await run_audit_pipeline_langgraph(request, context)
+        return _extract_output(result, "langgraph")
+
     # Default: async backend
     result = await run_audit_pipeline_async(request, context)
-
-    # Non-success statuses must return a meaningful error JSON so the
-    # web UI and MCP clients can show "Access denied" instead of empty output.
-    if result.status in ("rbac_denied", "blocked", "error") or result.error:
-        if result.decisions and result.decisions[-1].sanitized_text:
-            return result.decisions[-1].sanitized_text, {"backend": "async"}
-        if result.error:
-            return json.dumps({"error": result.error}), {"backend": "async"}
-        return json.dumps({"error": result.status}), {"backend": "async"}
-
-    return result.decisions[-1].sanitized_text if result.decisions else "", {"backend": "async"}
+    return _extract_output(result, "async")
 
 
 async def _run_temporal(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,18 +1,18 @@
 # Architecture — auditguard-mcp v2
 
-This document explains the architectural decisions behind the v2 pipeline redesign, specifically the introduction of Temporal as an optional orchestration backend.
+This document explains the architectural decisions behind the v2 pipeline redesign: the ports-and-adapters stage model and the three orchestration backends (async, LangGraph, Temporal).
 
 ## Core Principle: Separate Stage Logic from Orchestration
 
 The most important architectural decision in v2 is that the 7 pipeline stages are **pure functions** that don't know how they're being orchestrated. This is the ports-and-adapters (hexagonal) pattern:
 
 - **Ports**: The stage functions in `pipeline/stages.py` — pure, side-effect-free (except audit log write), deterministic.
-- **Adapters**: `async_runner.py` and `temporal_runner.py` — thin wrappers that call the stages in the right order, with the right concurrency model, retry policy, and durability guarantees.
+- **Adapters**: `async_runner.py`, `langgraph_runner.py`, and `temporal_runner.py` — thin wrappers that call the stages in the right order, with the right concurrency model, retry policy, and durability guarantees.
 
 This means:
-1. **Stage logic is tested once**, not twice. `test_pipeline_stages.py` covers all the business logic.
-2. **Behavior is identical across backends**. Both async and Temporal run the same `check_rbac()`, `scan_inbound_pii()`, etc.
-3. **Adding a third backend** (e.g., AWS Step Functions, Celery, Airflow) requires writing only the adapter — ~100 lines, not 400.
+1. **Stage logic is tested once**, not three times. `test_pipeline_stages.py` covers all the business logic.
+2. **Behavior is identical across backends**. All three backends run the same `check_rbac()`, `scan_inbound_pii()`, etc.
+3. **Adding another backend** (e.g., AWS Step Functions, Celery) requires writing only the adapter — ~100 lines, not 400.
 
 ## Type Boundaries
 
@@ -55,6 +55,36 @@ async def run_audit_pipeline_async(request, context):
 ```
 
 **Durability gap**: If the Python process crashes after Stage 4 but before Stage 7, the audit log entry is lost. The request is also lost. This is acceptable for high-throughput, stateless workloads where the client can retry.
+
+## LangGraph Backend
+
+The LangGraph backend expresses the same 7-stage pipeline as an explicit `StateGraph`. Each stage is a node; short-circuit paths are conditional edges. The key differences from the async backend:
+
+**State threading.** A `PipelineState` TypedDict is passed through every node. Nodes return partial dicts; LangGraph merges them by key overwrite. This makes the accumulated decisions and detections visible to every downstream node and — critically — to the error handler.
+
+**Routing via conditional edges.** Where the async backend uses `if inbound_decision.action in (DENY, BLOCK)`, the LangGraph backend encodes this in a routing function attached to a conditional edge:
+
+```python
+def route_after_policy_inbound(state):
+    if state["route"] in ("short_circuit", "human_review"):
+        return "audit_log"
+    return "execute"
+```
+
+This makes branching topology inspectable at compile time (`_PIPELINE_GRAPH.get_graph()`) and verifiable before any request is processed.
+
+**Partial-state error recovery.** The entrypoint uses `astream(stream_mode="values")` rather than `ainvoke`. `last_state` is updated after every node snapshot. If `node_execute` raises mid-pipeline, the error handler writes an audit log using `last_state` — which already contains the inbound PII scan and policy decision — rather than the empty initial state. The async backend cannot do this without significant restructuring.
+
+**Graph topology:**
+```
+START → rbac → scan_inbound → policy_inbound → execute → scan_outbound → policy_outbound → audit_log → END
+          ↘ audit_log ↗              ↘ audit_log ↗
+         (rbac_denied)         (short_circuit / human_review)
+```
+
+All paths converge on `audit_log`, guaranteeing a structured record regardless of exit point.
+
+See [`LANGGRAPH.md`](../LANGGRAPH.md) for the full state schema, node-by-node mapping, and branching rules table.
 
 ## Temporal Backend
 
@@ -113,7 +143,7 @@ Both backends use the same registry. `execute_bounded()` looks up the tool by na
 
 ```python
 class AuditConfig(BaseModel):
-    backend: Literal["async", "temporal"] = "async"
+    backend: Literal["async", "temporal", "langgraph"] = "async"
     policy_mode: Literal["permissive", "strict"] = "permissive"
     pii_threshold: float = 0.7
     timeout_seconds: int = 30
@@ -129,6 +159,7 @@ Read from environment variables (`AUDITGUARD_BACKEND`, `TEMPORAL_ADDRESS`, etc.)
 |-----------|---------------|
 | `test_pipeline_stages.py` | Each stage in isolation (RBAC, PII scan, policy, audit log) |
 | `test_async_runner.py` | End-to-end async pipeline (happy path, RBAC denial, policy block, audit completeness) |
+| `test_langgraph_runner.py` | LangGraph graph semantics (happy path, RBAC denial, inbound block, outbound transform, human-review short-circuit, partial-state error recovery, server dispatch safety) |
 | `test_temporal_runner.py` | Temporal workflow semantics (happy path, RBAC failure, signal handling) using `WorkflowEnvironment` |
 
 The Temporal tests use `WorkflowEnvironment.start_time_skipping()` — a test-only in-memory Temporal server that runs workflows instantly. No Docker required. This is the killer feature for testing durable workflows.
@@ -147,12 +178,12 @@ To fully migrate:
 2. Deprecate `_process_pipeline()`.
 3. Update `demo_query` to use the new pipeline exclusively.
 
-## Future Backends
+## Adding Further Backends
 
-Adding a third backend requires:
-1. Create `pipeline/new_backend_runner.py`.
-2. Implement the 7-stage orchestration in the new backend's paradigm.
-3. Import the runner in `server.py` and add a branch in `_run_pipeline_v2()`.
-4. Write backend-specific tests.
+The LangGraph backend proves the pattern. Adding another backend (e.g., AWS Step Functions, Celery, Prefect) requires:
+1. Create `pipeline/new_backend_runner.py` — implement the 7-stage sequence in the new paradigm.
+2. Widen `backend: Literal[...]` in `config.py` and `types.py`.
+3. Add a dispatch branch in `server.py:_run_pipeline_v2()` using `_extract_output()` for the response conversion.
+4. Write backend-specific tests mirroring `test_langgraph_runner.py`.
 
-Estimated effort: ~100 lines of adapter code + ~50 lines of tests.
+Estimated effort: ~100 lines of adapter code + ~60 lines of tests. Stage logic in `stages.py` is never touched.

--- a/examples/run_langgraph_backend.py
+++ b/examples/run_langgraph_backend.py
@@ -1,0 +1,72 @@
+"""Example: run the LangGraph backend directly.
+
+Demonstrates graph-native orchestration with the same 7-stage pipeline.
+No Temporal cluster required. Set AUDITGUARD_BACKEND=langgraph in production.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+from auditguard_mcp.config import get_config, set_config
+from auditguard_mcp.pipeline.types import AuditRequest, AuditContext, PolicyMode
+from auditguard_mcp.pipeline.langgraph_runner import run_audit_pipeline_langgraph
+from auditguard_mcp.privacy import use_mock_detector
+
+
+async def main():
+    # Use mock PII detector for fast demo (no model download)
+    use_mock_detector(True)
+
+    set_config(get_config().model_copy(update={"backend": "langgraph"}))
+
+    scenarios = [
+        {
+            "label": "Analyst -- clean query (expect: ALLOW)",
+            "role": "analyst",
+            "query": "SELECT id, first_name FROM customers LIMIT 5",
+            "scan_text": "SELECT id, first_name FROM customers LIMIT 5",
+        },
+        {
+            "label": "Intern -- blocked by RBAC (expect: RBAC_DENIED)",
+            "role": "intern",
+            "query": "SELECT * FROM customers",
+            "scan_text": "SELECT * FROM customers",
+        },
+        {
+            "label": "Analyst -- SSN in scan text (expect: BLOCK)",
+            "role": "analyst",
+            "query": "SELECT id FROM customers LIMIT 1",
+            "scan_text": "My SSN is 123-45-6789",
+        },
+    ]
+
+    for s in scenarios:
+        print(f"\n{'─' * 60}")
+        print(f"  {s['label']}")
+        print(f"{'─' * 60}")
+
+        request = AuditRequest(
+            request_id=str(uuid.uuid4()),
+            role=s["role"],  # type: ignore[arg-type]
+            tool_name="sql_query",
+            tool_input={"query": s["query"]},
+            scan_text=s["scan_text"],
+            requester="demo-user",
+        )
+        context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+        result = await run_audit_pipeline_langgraph(request, context)
+
+        print(f"  backend      : {result.backend}")
+        print(f"  status       : {result.status}")
+        print(f"  final_action : {result.final_action.value}")
+        print(f"  duration     : {result.duration_ms}ms")
+        if result.error:
+            print(f"  error        : {result.error}")
+        for i, d in enumerate(result.decisions, 1):
+            print(f"  decision[{i}]  : {d.action.value} — {d.reason}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -65,7 +65,7 @@ def audit_path(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_happy_path_sql_query(audit_path):
+async def test_happy_path_sql_query(audit_path, db_path):
     request = AuditRequest(
         request_id="test-happy-001",
         role=Role.ANALYST,
@@ -170,7 +170,7 @@ async def test_review_queued(audit_path, db_path):
 
 
 @pytest.mark.asyncio
-async def test_audit_record_fields(audit_path):
+async def test_audit_record_fields(audit_path, db_path):
     request = AuditRequest(
         request_id="test-audit-001",
         role=Role.ANALYST,

--- a/tests/test_langgraph_runner.py
+++ b/tests/test_langgraph_runner.py
@@ -1,0 +1,322 @@
+"""Tests for the LangGraph runner -- mirrors test_async_runner.py.
+
+Same 7-stage pipeline, same assertions. Confirms semantic equivalence
+between the langgraph and async backends.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("langgraph", reason="langgraph not installed")
+
+from auditguard_mcp.models import RequestStatus, Role
+from auditguard_mcp.pipeline.types import (
+    AuditRequest,
+    AuditContext,
+    PipelineAction,
+    PolicyMode,
+)
+from auditguard_mcp.pipeline.langgraph_runner import run_audit_pipeline_langgraph
+from auditguard_mcp.privacy import use_mock_detector
+
+
+@pytest.fixture(autouse=True)
+def _use_mock():
+    use_mock_detector(True)
+    yield
+    use_mock_detector(False)
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    """Temp SQLite database seeded with minimal data."""
+    import sqlite3
+    db = str(tmp_path / "test_db.sqlite")
+    monkeypatch.setenv("DB_PATH", db)
+    sqlite3.connect(db).close()
+    import auditguard_mcp.tools.sql_query as sql_module
+    sql_module._engine = None
+    sql_module._DB_PATH = db
+    from auditguard_mcp.tools.sql_query import _get_engine
+    from sqlalchemy import text
+    engine = _get_engine()
+    with engine.connect() as conn:
+        conn.execute(text(
+            "CREATE TABLE IF NOT EXISTS customers "
+            "(id INTEGER PRIMARY KEY, first_name TEXT, last_name TEXT)"
+        ))
+        conn.execute(text(
+            "INSERT INTO customers (first_name, last_name) "
+            "VALUES ('Alice', 'Smith'), ('Bob', 'Jones')"
+        ))
+        conn.commit()
+    return db
+
+
+@pytest.fixture
+def audit_path(tmp_path, monkeypatch):
+    path = str(tmp_path / "audit.jsonl")
+    monkeypatch.setenv("AUDIT_LOG_PATH", path)
+    from auditguard_mcp.pipeline import stages
+    from auditguard_mcp.audit import AuditLogger
+    stages._audit_logger = AuditLogger(path=path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_sql_query(audit_path, db_path):
+    request = AuditRequest(
+        request_id="lg-happy-001",
+        role=Role.ANALYST,
+        tool_name="sql_query",
+        tool_input={"query": "SELECT id, first_name FROM customers LIMIT 2"},
+        scan_text="SELECT id, first_name FROM customers LIMIT 2",
+        requester="test-analyst",
+    )
+    context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+    result = await run_audit_pipeline_langgraph(request, context)
+
+    assert result.backend == "langgraph"
+    assert result.status == RequestStatus.SUCCESS.value
+    assert result.final_action == PipelineAction.ALLOW
+    assert result.duration_ms > 0
+    assert len(result.decisions) >= 1
+
+
+# ---------------------------------------------------------------------------
+# RBAC denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_intern_rbac_denial(audit_path):
+    request = AuditRequest(
+        request_id="lg-rbac-001",
+        role=Role.INTERN,
+        tool_name="sql_query",
+        tool_input={"query": "SELECT * FROM customers"},
+        scan_text="SELECT * FROM customers",
+        requester="test-intern",
+    )
+    context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+    result = await run_audit_pipeline_langgraph(request, context)
+
+    assert result.backend == "langgraph"
+    assert result.status == RequestStatus.RBAC_DENIED.value
+    assert result.error is not None
+    assert "RBAC" in result.error or "rbac" in result.error
+    assert len(result.decisions) == 1
+    assert result.decisions[0].action == PipelineAction.DENY
+
+
+# ---------------------------------------------------------------------------
+# Inbound block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blocked_by_inbound_policy(audit_path, db_path):
+    request = AuditRequest(
+        request_id="lg-block-001",
+        role=Role.ANALYST,
+        tool_name="sql_query",
+        tool_input={"query": "SELECT id, first_name FROM customers LIMIT 1"},
+        scan_text="My SSN is 123-45-6789",  # triggers SECRET -> BLOCK
+        requester="test-analyst",
+    )
+    context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+    result = await run_audit_pipeline_langgraph(request, context)
+
+    assert result.backend == "langgraph"
+    assert result.final_action in (PipelineAction.BLOCK, PipelineAction.DENY)
+
+
+# ---------------------------------------------------------------------------
+# Outbound transform -- PII redacted in tool output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outbound_transform(audit_path, db_path, monkeypatch):
+    """Injects a mock tool that returns PII so outbound policy runs."""
+    import auditguard_mcp.pipeline.langgraph_runner as lg
+    from auditguard_mcp.tools import registry as reg
+
+    async def _pii_tool(tool_input, role):
+        return "Customer email: alice@example.com, SSN: 123-45-6789"
+
+    # Bypass RBAC so the custom tool name is allowed
+    monkeypatch.setattr(lg, "check_rbac", lambda request, context: None)
+
+    original = dict(reg.TOOL_REGISTRY)
+    reg.TOOL_REGISTRY["pii_tool"] = _pii_tool
+    try:
+        request = AuditRequest(
+            request_id="lg-out-001",
+            role=Role.ANALYST,
+            tool_name="pii_tool",
+            tool_input={},
+            scan_text="",
+            requester="test-analyst",
+        )
+        context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+        result = await run_audit_pipeline_langgraph(request, context)
+        assert result.backend == "langgraph"
+        # Two decisions: inbound + outbound
+        assert len(result.decisions) == 2
+    finally:
+        reg.TOOL_REGISTRY.clear()
+        reg.TOOL_REGISTRY.update(original)
+
+
+# ---------------------------------------------------------------------------
+# Human-review short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_human_review_short_circuit(audit_path, monkeypatch):
+    """HUMAN_REVIEW inbound action causes immediate short-circuit (no execution)."""
+    import auditguard_mcp.pipeline.langgraph_runner as lg
+    from auditguard_mcp.pipeline.types import PipelineDecision, PipelineAction
+
+    def _force_review(request, pii_result, context):
+        return PipelineDecision(
+            action=PipelineAction.HUMAN_REVIEW,
+            reason="Forced review for test",
+            triggered_rules=["test"],
+        )
+
+    # Patch the runner's local binding (imported at module load, not stages attribute)
+    monkeypatch.setattr(lg, "apply_inbound_policy", _force_review)
+
+    request = AuditRequest(
+        request_id="lg-review-001",
+        role=Role.ANALYST,
+        tool_name="sql_query",
+        tool_input={"query": "SELECT id FROM customers LIMIT 1"},
+        scan_text="",
+        requester="test-analyst",
+    )
+    context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+    result = await run_audit_pipeline_langgraph(request, context)
+
+    assert result.backend == "langgraph"
+    assert result.status == RequestStatus.REVIEW_QUEUED.value
+    assert result.final_action == PipelineAction.HUMAN_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# Audit record completeness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_record_fields(audit_path, db_path):
+    request = AuditRequest(
+        request_id="lg-audit-001",
+        role=Role.ANALYST,
+        tool_name="sql_query",
+        tool_input={"query": "SELECT id FROM customers LIMIT 1"},
+        scan_text="SELECT id FROM customers LIMIT 1",
+        requester="test-analyst",
+    )
+    context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+    result = await run_audit_pipeline_langgraph(request, context)
+
+    assert result.request_id == "lg-audit-001"
+    assert result.role == Role.ANALYST
+    assert result.tool_name == "sql_query"
+    assert result.timestamp is not None
+
+    with open(audit_path) as f:
+        data = json.loads(f.readline().strip())
+    assert data["request_id"] == "lg-audit-001"
+    assert data["actor"]["role"] == "analyst"
+
+
+# ---------------------------------------------------------------------------
+# Partial-state preservation on mid-pipeline error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_error_preserves_partial_state(audit_path, monkeypatch):
+    """If execution fails after inbound scan, the audit log still carries
+    the inbound decision -- not an empty decisions list."""
+    import auditguard_mcp.pipeline.langgraph_runner as lg
+
+    async def _boom(request, decision, context):
+        raise RuntimeError("simulated tool crash")
+
+    # Patch the runner's local binding (imported at module load, not stages attribute)
+    monkeypatch.setattr(lg, "execute_bounded", _boom)
+
+    request = AuditRequest(
+        request_id="lg-error-001",
+        role=Role.ANALYST,
+        tool_name="sql_query",
+        tool_input={"query": "SELECT id FROM customers LIMIT 1"},
+        scan_text="",
+        requester="test-analyst",
+    )
+    context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+    result = await run_audit_pipeline_langgraph(request, context)
+
+    assert result.backend == "langgraph"
+    assert result.status == RequestStatus.ERROR.value
+    # Inbound policy decision must be preserved despite the crash
+    assert len(result.decisions) >= 1, "partial decisions lost on error"
+
+
+# ---------------------------------------------------------------------------
+# Server dispatch: blocked content must never reach the MCP client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_blocked_content_not_leaked(audit_path, monkeypatch):
+    """_run_pipeline_v2 with langgraph backend must return error JSON, not the
+    original blocked text, when an inbound BLOCK is triggered by sensitive content."""
+    from auditguard_mcp.config import AuditConfig, set_config
+    from auditguard_mcp.server import _run_pipeline_v2
+
+    set_config(AuditConfig(backend="langgraph"))
+    monkeypatch.setattr(
+        "auditguard_mcp.server._extract_output.__module__",
+        "auditguard_mcp.server",
+        raising=False,
+    )
+
+    secret = "123-45-6789"
+    request = AuditRequest(
+        request_id="lg-dispatch-block-001",
+        role=Role.ANALYST,
+        tool_name="sql_query",
+        tool_input={"query": "SELECT id FROM customers LIMIT 1"},
+        scan_text=f"My SSN is {secret}",
+        requester="test-analyst",
+    )
+    context = AuditContext(policy_mode=PolicyMode.PERMISSIVE)
+
+    output, meta = await _run_pipeline_v2(request, context)
+
+    assert meta["backend"] == "langgraph"
+    # The raw SSN must never appear in the returned output
+    assert secret not in output, f"blocked content leaked to MCP client: {output!r}"
+    # Output must be error JSON, not empty string
+    parsed = json.loads(output)
+    assert "error" in parsed

--- a/web/index.html
+++ b/web/index.html
@@ -201,6 +201,10 @@
     color: var(--amber);
     background: var(--amber-dim);
   }
+  .ctx-backend.langgraph {
+    color: var(--accent);
+    background: var(--accent-dim);
+  }
   .ctx-backend-dot {
     width: 5px; height: 5px;
     border-radius: 50%;
@@ -208,6 +212,7 @@
   }
   .ctx-backend.async .ctx-backend-dot { background: var(--text-dim); }
   .ctx-backend.temporal .ctx-backend-dot { background: var(--amber); }
+  .ctx-backend.langgraph .ctx-backend-dot { background: var(--accent); }
 
   /* ── Pipeline ── */
   .pipe-track {
@@ -868,6 +873,12 @@ async function run(role, query, sql) {
           linkEl.style.display = 'inline';
         }
         metaEl.textContent = backendMeta.workflow_id || '';
+      } else if (backendMeta.backend === 'langgraph') {
+        backendEl.className = 'ctx-backend langgraph';
+        backendLabel.textContent = 'LangGraph';
+        backendEl.style.display = 'inline-flex';
+        linkEl.style.display = 'none';
+        metaEl.textContent = '';
       } else {
         backendEl.className = 'ctx-backend async';
         backendLabel.textContent = 'Async';


### PR DESCRIPTION
Ports the 7-stage audit pipeline to a third backend alongside async and Temporal. Each stage becomes a graph node; conditional edges encode the RBAC-denial, inbound-block, and human-review short-circuit paths explicitly rather than as imperative if-else chains.

Key design decisions:
- PipelineState TypedDict threads accumulated decisions/detections through every node so error-path audit records carry full partial state
- astream(stream_mode="values") over ainvoke so last_state is always the latest snapshot — fixes the partial-state data-loss risk on mid-pipeline failures
- _extract_output() helper shared by async and langgraph dispatch paths ensures non-success statuses never return sanitized_text (which holds the original blocked content on BLOCK decisions) — fixes security regression
- LangGraph chip added to web UI (blue, distinct from async grey and Temporal amber)

Files added: langgraph_runner.py, test_langgraph_runner.py (8 tests), run_langgraph_backend.py, LANGGRAPH.md
Files updated: config.py, types.py, server.py, README.md, docs/architecture.md, web/index.html